### PR TITLE
33 updatera frontend productcard

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @plugin "tailwindcss-animate";
 
@@ -9,10 +9,10 @@
   --card-foreground: oklch(0.129 0.042 264.695);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.129 0.042 264.695);
-  --primary: oklch(0.208 0.042 265.755);
+  --primary: oklch(0.429 0.049 78.22);
   --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.968 0.007 247.896);
-  --secondary-foreground: oklch(0.208 0.042 265.755);
+  --secondary: oklch(0.2297 0.0634 134.73);
+  --secondary-foreground: oklch(0.984 0.003 247.858);
   --muted: oklch(0.968 0.007 247.896);
   --muted-foreground: oklch(0.554 0.046 257.417);
   --accent: oklch(0.968 0.007 247.896);

--- a/components/buttons/AddToCartButton.tsx
+++ b/components/buttons/AddToCartButton.tsx
@@ -17,17 +17,18 @@ export default function AddToCartButton({ id, title, price, image }: AddToCartBu
   const handleAddToCart = () => {
     addToCart({ id, title, price, quantity: 1, image });
     toast.success(
-      <span data-cy="added-to-cart-toast">
-        <strong>{title}</strong> has been added!
-      </span>
+      <>
+        <span>
+          <strong>{title}</strong> has been added!
+        </span>
+      </>
     );
   };
 
   return (
     <Button
-      data-cy="product-buy-button"
       onClick={handleAddToCart}
-      className="mt-3 w-full cursor-pointer rounded py-4"
+      className="mt-3 w-full cursor-pointer py-4"
     >
       Buy
     </Button>

--- a/components/products/ProductCard.tsx
+++ b/components/products/ProductCard.tsx
@@ -28,7 +28,7 @@ export default function ProductCard({ product }: ProductCardProps) {
                         alt=''
                         width={350}
                         height={350}
-                        className="object-cover w-full h-[300px] md:h-[200px] lg:h-[250px] xl:h-[350px] 
+                        className="object-cover w-full h-[300px] md:w-auto md:h-[200px] lg:w-auto lg:h-[250px] xl:w-auto xl:h-[350px] 
                       transition-transform duration-300 ease-out 
                       group-hover:scale-110 hover:scale-110"
                     />

--- a/components/products/ProductCard.tsx
+++ b/components/products/ProductCard.tsx
@@ -15,28 +15,39 @@ export default function ProductCard({ product }: ProductCardProps) {
         <div
             key={product.articleNumber}
             data-cy="product"
-            className="border p-4 shadow-md bg-white flex flex-col md:flex-col items-start md:items-center gap-4 transition-all duration-300 ease-out hover:scale-[1.03] hover:shadow-lg"
+            className="p-4 shadow-sm bg-white flex flex-col md:flex-col justify-between items-start md:items-center gap-4 hover:shadow-lg"
         >
             {/* Top Section: Mobile = row, Desktop = column */}
             <Link
                 href={`/product/${product.articleNumber}/${product.title}`}
                 className="flex flex-col md:flex-col items-start md:items-center w-full gap-4"
             >
-                <Image
-                    src={product.image}
-                    alt=''
-                    width={150}
-                    height={150}
-                    className="object-cover w-full h-[200px] sm:h-[150px] md:h-[200px] lg:h-[250px]"
-                />
+                <div className="overflow-hidden w-full">
+                    <Image
+                        src={product.image}
+                        alt=''
+                        width={150}
+                        height={150}
+                        className="object-cover w-full h-[200px] sm:h-[150px] md:h-[200px] lg:h-[250px] 
+                      transition-transform duration-300 ease-out 
+                      group-hover:scale-110 hover:scale-110"
+                    />
+                </div>
 
-                <div className="flex flex-col justify-center md:items-center flex-1">
-                    <h2
-                        className="text-base md:text-lg font-semibold hover:underline"
-                    >
-                        {product.title}
+                <div className="flex flex-col justify-center items-center flex-1">
+                    <h2 className="text-base md:text-lg font-semibold hover:underline">
+                        {product.title.includes('(') ? (
+                            <div className="flex flex-col gap-0 items-center">
+                                <span>{product.title.split('(')[0].trim()}</span>
+                                <span className="text-sm">
+                                    ({product.title.split('(')[1]}
+                                </span>
+                            </div>
+                        ) : (
+                            product.title
+                        )}
                     </h2>
-                    <p className="text-gray-700">
+                    <p className="text-gray-800">
                         {product.price} SEK
                     </p>
                 </div>

--- a/components/products/ProductCard.tsx
+++ b/components/products/ProductCard.tsx
@@ -15,26 +15,26 @@ export default function ProductCard({ product }: ProductCardProps) {
         <div
             key={product.articleNumber}
             data-cy="product"
-            className="p-4 shadow-sm bg-white flex flex-col md:flex-col justify-between items-start md:items-center gap-4 hover:shadow-lg"
+            className="p-4 shadow-sm bg-white flex flex-col justify-between hover:shadow-lg"
         >
             {/* Top Section: Mobile = row, Desktop = column */}
             <Link
                 href={`/product/${product.articleNumber}/${product.title}`}
-                className="flex flex-col md:flex-col items-start md:items-center w-full gap-4"
+                className="flex flex-col items-center gap-4"
             >
                 <div className="overflow-hidden w-full">
                     <Image
                         src={product.image}
                         alt=''
-                        width={150}
-                        height={150}
-                        className="object-cover w-full h-[200px] sm:h-[150px] md:h-[200px] lg:h-[250px] 
+                        width={350}
+                        height={350}
+                        className="object-cover w-full h-[300px] md:h-[200px] lg:h-[250px] xl:h-[350px] 
                       transition-transform duration-300 ease-out 
                       group-hover:scale-110 hover:scale-110"
                     />
                 </div>
 
-                <div className="flex flex-col justify-center items-center flex-1">
+                <div className="flex flex-col items-center flex-1">
                     <h2 className="text-base md:text-lg font-semibold hover:underline">
                         {product.title.includes('(') ? (
                             <div className="flex flex-col gap-0 items-center">

--- a/components/products/ProductCard.tsx
+++ b/components/products/ProductCard.tsx
@@ -15,29 +15,28 @@ export default function ProductCard({ product }: ProductCardProps) {
         <div
             key={product.articleNumber}
             data-cy="product"
-            className="border rounded-md p-4 shadow-md bg-white flex flex-col md:flex-col items-start md:items-center gap-4 transition-transform hover:scale-105"
+            className="border p-4 shadow-md bg-white flex flex-col md:flex-col items-start md:items-center gap-4 transition-all duration-300 ease-out hover:scale-[1.03] hover:shadow-lg"
         >
             {/* Top Section: Mobile = row, Desktop = column */}
             <Link
                 href={`/product/${product.articleNumber}/${product.title}`}
-                className="flex flex-row md:flex-col items-start md:items-center w-full gap-4"
+                className="flex flex-col md:flex-col items-start md:items-center w-full gap-4"
             >
                 <Image
                     src={product.image}
-                    alt={product.title}
+                    alt=''
                     width={150}
                     height={150}
-                    className="object-contain w-[100px] h-[100px] md:w-[150px] md:h-[150px] rounded-md"
+                    className="object-cover w-full h-[200px] sm:h-[150px] md:h-[200px] lg:h-[250px]"
                 />
 
                 <div className="flex flex-col justify-center md:items-center flex-1">
                     <h2
-                        data-cy="product-title"
                         className="text-base md:text-lg font-semibold hover:underline"
                     >
                         {product.title}
                     </h2>
-                    <p data-cy="product-price" className="text-gray-700">
+                    <p className="text-gray-700">
                         {product.price} SEK
                     </p>
                 </div>
@@ -52,7 +51,7 @@ export default function ProductCard({ product }: ProductCardProps) {
                     image={product.image}
                 />
                 <Link href={`/product/${product.articleNumber}/${product.title}`}>
-                    <Button className="bg-slate-500 w-full rounded-xs cursor-pointer">
+                    <Button variant="secondary" size="full">
                         Info
                     </Button>
                 </Link>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,box-shadow] cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -16,14 +16,15 @@ const buttonVariants = cva(
         outline:
           "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/90",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-8 gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 px-6 has-[>svg]:px-4",
+        full: "w-full h-9 px-4 py-2 has-[>svg]:px-3",
         icon: "size-9",
       },
     },
@@ -56,3 +57,4 @@ function Button({
 }
 
 export { Button, buttonVariants }
+


### PR DESCRIPTION
Adjusted primary and secondary colors
Primary (Buy) to `oklch(0.429 0.049 78.22)` 
Seconady (Info) to `oklch(0.2297 0.0634 134.73)`

Roundness off on:
- Card
- Image
- Button

Other UI changes:
- Made scaling on image (in frame) only and not the whole card.
- If () in the title that will be on a new row.
- Buttons at bottom of the card with justify-content: space between