### PR TITLE
60 fix lint errors

### DIFF
--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,19 +1,16 @@
 'use server';
 
 import { Product } from '@/generated/prisma';
+import { productSchema } from '@/lib/schemas';
+import { db } from '@/prisma/client';
 import { nanoid } from 'nanoid';
 import { revalidatePath } from 'next/cache';
-import { db } from 'prisma/client';
-import { z } from 'zod';
-import { productSchema } from '@/lib/schemas';
-
 
 export async function getAllProducts() {
   return await db.product.findMany({
     include: { categories: true },
   });
 }
-
 
 export async function createProduct(
   data: Partial<Product>,
@@ -62,7 +59,6 @@ export async function createProduct(
   }
 }
 
-
 export async function updateProduct(
   articleNumber: string,
   data: Partial<Product>,
@@ -109,7 +105,6 @@ export async function updateProduct(
   }
 }
 
-
 export async function deleteProduct(articleNumber: string) {
   await db.product.delete({
     where: { articleNumber },
@@ -117,13 +112,11 @@ export async function deleteProduct(articleNumber: string) {
   revalidatePath('/admin');
 }
 
-
 export async function getCategories() {
   return await db.category.findMany({
     select: { name: true, id: true },
   });
 }
-
 
 export async function updateOrderStatus() {
   // TODO: Implement order status update logic

--- a/app/confirmation/[orderNumber]/page.tsx
+++ b/app/confirmation/[orderNumber]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import useCartStore from "@/stores/cartStore";
 import Image from "next/image";
+import Link from "next/link";
 
 interface ConfirmationPageProps {
   params: {
@@ -26,7 +27,7 @@ export default function ConfirmationPage({ params: { orderNumber } }: Confirmati
     (sum, item) => sum + item.price * item.quantity,
     0
   );
-  
+
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -139,9 +140,9 @@ export default function ConfirmationPage({ params: { orderNumber } }: Confirmati
           <CardContent className="flex flex-col gap-2">
             {/* Button linking back to homepage */}
             <Button asChild>
-              <a href="/" data-cy="continue-shopping-button">
+              <Link href="/" data-cy="continue-shopping-button">
                 Continue Shopping
-              </a>
+              </Link>
             </Button>
             {/* Additional post-checkout details if needed */}
           </CardContent>
@@ -150,5 +151,5 @@ export default function ConfirmationPage({ params: { orderNumber } }: Confirmati
 
     </div>
   );
-} 
+}
 

--- a/app/product/[articleNumber]/[title]/page.tsx
+++ b/app/product/[articleNumber]/[title]/page.tsx
@@ -1,5 +1,5 @@
 import AddToCartButton from "@/components/buttons/AddToCartButton";
-import { db } from "prisma/client";
+import { db } from "@/prisma/client";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 

--- a/app/product/page.tsx
+++ b/app/product/page.tsx
@@ -1,5 +1,5 @@
 import ProductCard from "@/components/products/ProductCard";
-import { db } from "prisma/client";
+import { db } from "@/prisma/client";
 import { FaBoxOpen } from "react-icons/fa";
 
 export default async function ProductsPage() {

--- a/components/CartPopup.tsx
+++ b/components/CartPopup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { FaMinus, FaPlus, FaTrashAlt } from "react-icons/fa";
@@ -33,7 +34,7 @@ export default function CartPopup({ isOpen, onClose }: CartPopupProps) {
         }, 300);
     };
 
-    
+
     useEffect(() => {
         if (isOpen) setIsClosing(false);
     }, [isOpen]);
@@ -60,9 +61,11 @@ export default function CartPopup({ isOpen, onClose }: CartPopupProps) {
                             className="border-b border-b-[#4B352A] py-4 flex justify-between items-center flex-wrap"
                         >
                             {/* Product Image */}
-                            <img
+                            <Image
                                 src={item.image}
                                 alt={item.title}
+                                width={64}
+                                height={64}
                                 className="w-16 h-16 object-contain rounded-md mb-4 sm:mb-0"
                             />
                             <div className="flex flex-col items-start ml-10 flex-1 min-w-0">

--- a/components/checkout/CheckoutForm.tsx
+++ b/components/checkout/CheckoutForm.tsx
@@ -3,6 +3,7 @@
 import useCartStore from "@/stores/cartStore";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { nanoid } from "nanoid";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -58,7 +59,7 @@ export default function CheckoutForm() {
       city: data.city,
     });
 
-    
+
     const orderNumber = nanoid(8);
 
     const { setCheckoutItems, clearCart } = useCartStore.getState();
@@ -67,10 +68,10 @@ export default function CheckoutForm() {
 
     clearCart();
 
-    
+
     router.push(`/confirmation/${orderNumber}`);
 
-    };
+  };
 
   return (
     <form
@@ -197,10 +198,12 @@ export default function CheckoutForm() {
           </p>
         )}
         <div className="w-full md:w-[50%] flex justify-center items-center mt-4">
-          <img
+          <Image
             className="cursor-pointer"
             src="/Credit-Card-Icons.png"
             alt="credit cards"
+            width={300}
+            height={50}
           />
         </div>
       </div>


### PR DESCRIPTION
Fixat följande

Justerat import
Från 'prisma/client' till '@/prisma/client'

app\admin\actions.ts
app\product\page.tsx
app\product[articleNumber]\[title]\page.tsx

------------------

./app/confirmation/[orderNumber]/page.tsx
142:15  Error: Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages  @next/next/no-html-link-for-pages

------------------

./components/CartPopup.tsx
63:29  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element

------------------

./components/checkout/CheckoutForm.tsx
200:11  Warning: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` or a custom image loader to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element